### PR TITLE
fixes for eimage files

### DIFF
--- a/bin/imsim.py
+++ b/bin/imsim.py
@@ -103,6 +103,9 @@ def main():
                               m5=defaults.m5(bandpass),
                               seeing=seeing)
 
+    # Set the OpsimMetaData attribute with the obshistID info.
+    obs.OpsimMetaData = {'obshistID': visitID}
+
     # Now further sub-divide the source dataframe into stars and galaxies.
     if arguments.sensor is not None:
         # Trim the input catalog to a single chip.
@@ -148,7 +151,7 @@ def main():
     outdir = arguments.outdir
     if not os.path.isdir(outdir):
         os.makedirs(outdir)
-    phoSimGalaxyCatalog.write_images(nameRoot=os.path.join(outdir, 'e-image_') +
+    phoSimGalaxyCatalog.write_images(nameRoot=os.path.join(outdir, 'lsst_e_') +
                                      str(visitID))
 
 if __name__ == "__main__":

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -253,7 +253,8 @@ def photometricParameters(phosim_commands):
     The effects from all three of those will be added by the
     electronics chain readout code.
     """
-    return PhotometricParameters(exptime=phosim_commands['vistime'],
+    exptime = phosim_commands['vistime']/float(phosim_commands['nsnap'])
+    return PhotometricParameters(exptime=exptime,
                                  nexp=phosim_commands['nsnap'],
                                  gain=1,
                                  readnoise=0,

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -1,7 +1,7 @@
 """
 Base module for the imSim package.
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import warnings
 from collections import namedtuple
 import numpy as np


### PR DESCRIPTION
Two items:
* In order for `ingestSimImages.py` (from `obs_lsstSim`) to process the eimages, the `obshistID` needs to be set in the header (see [here](https://github.com/lsst/sims_GalSimInterface/blob/56d725e0a73b4a97d8b3c5581aeb95ea19feeaab/python/lsst/sims/GalSimInterface/galSimDetector.py#L540) and [here](https://github.com/lsst/sims_GalSimInterface/blob/56d725e0a73b4a97d8b3c5581aeb95ea19feeaab/tests/testFitsHeaders.py#L79)) and the eimage filename has to start with `lsst_e` (see [here](https://github.com/lsst/obs_lsstSim/blob/1da903b9cd7e96231fe809d684ba3b73af1cb495/python/lsst/obs/lsstSim/ingest.py#L87)).
* The exposure time should be the visit time divided by the number of snaps.  The `sims_GalSimInterface` code adds the snaps together to produce a single eimage.