### PR TITLE
subclass derived classes of GalSimBase instead of replacing base class functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# backup files
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - ln -sf /home/travis/miniconda/lib/libcrypto.so.1.0.0 /home/travis/miniconda/lib/libcrypto.so.10
   - export PATH="$HOME/miniconda/bin:$PATH"
   - source eups-setups.sh
+  - conda install --es astropy=1.1.2
   - pip install coveralls
   - setup lsst_sims
   - eups declare -r . imsim -t current

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - ln -sf /home/travis/miniconda/lib/libcrypto.so.1.0.0 /home/travis/miniconda/lib/libcrypto.so.10
   - export PATH="$HOME/miniconda/bin:$PATH"
   - source eups-setups.sh
-  - conda install --es astropy=1.1.2
+  - conda install --yes astropy=1.1.2
   - pip install coveralls
   - setup lsst_sims
   - eups declare -r . imsim -t current

--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -8,16 +8,9 @@ code found in sims_GalSimInterface.
 from __future__ import absolute_import, print_function
 import os
 import argparse
-
 from lsst.obs.lsstSim import LsstSimMapper
-
-from lsst.sims.photUtils import LSSTdefaults
-from lsst.sims.utils import ObservationMetaData
 from lsst.sims.coordUtils import chipNameFromRaDec
-
-from lsst.sims.GalSimInterface import GalSimStars
-from lsst.sims.GalSimInterface import GalSimGalaxies
-
+from lsst.sims.GalSimInterface import GalSimStars, GalSimGalaxies
 import desc.imsim
 
 def main():
@@ -63,43 +56,21 @@ def main():
     phosim_objects = \
         desc.imsim.validate_phosim_object_list(phosim_objects).accepted
 
-    # Now build the ObservationMetaData with values taken from the PhoSim
-    # commands at the top of the instance file.
-
-    # Access the relevant pointing commands from the dictionary.
-    visitID = commands['obshistid']
-    mjd = commands['mjd']
-    rightAscension = commands['rightascension']
-    declination = commands['declination']
-    rotSkyPosition = commands['rotskypos']
-    bandpass = commands['bandpass']
-    # @todo: The seeing from the instance catalog is the seeing at
-    # 500nm at zenith.  Do we need to do a band-specific calculation?
-    seeing = commands['seeing']
-
-    # We need to set the M5 limiting magnitudes etc.
-    defaults = LSSTdefaults()
+    # Build the ObservationMetaData with values taken from the
+    # PhoSim commands at the top of the instance file.
+    obs_md = desc.imsim.phosim_obs_metadata(commands)
 
     camera = LsstSimMapper().camera
-    obs = ObservationMetaData(pointingRA=rightAscension,
-                              pointingDec=declination,
-                              mjd=mjd, rotSkyPos=rotSkyPosition,
-                              bandpassName=bandpass,
-                              m5=defaults.m5(bandpass),
-                              seeing=seeing)
 
-    # Set the OpsimMetaData attribute with the obshistID info.
-    obs.OpsimMetaData = {'obshistID': visitID}
-
-    # Now further sub-divide the source dataframe into stars and galaxies.
+    # Sub-divide the source dataframe into stars and galaxies.
     if arguments.sensor is not None:
         # Trim the input catalog to a single chip.
-        raICRS = phosim_objects['raICRS'].values
-        decICRS = phosim_objects['decICRS'].values
-        phosim_objects['chipName'] = chipNameFromRaDec(raICRS, decICRS,
-                                                       camera=camera,
-                                                       obs_metadata=obs,
-                                                       epoch=2000.0)
+        phosim_objects['chipName'] = \
+            chipNameFromRaDec(phosim_objects['raICRS'].values,
+                              phosim_objects['decICRS'].values,
+                              camera=camera, obs_metadata=obs_md,
+                              epoch=2000.0)
+
         starDataBase = \
             phosim_objects.query("galSimType=='pointSource' and chipName=='%s'"
                                  % arguments.sensor)
@@ -121,18 +92,16 @@ def main():
     # model are set.  For simulation the LSST this should be the same
     # between all types of objects.
 
-    phot_params = desc.imsim.photometricParameters(commands)
-
     # First simulate stars
     ImSimStars = desc.imsim.imSim_class_factory(GalSimStars)
-    phoSimStarCatalog = ImSimStars(starDataBase, obs)
-    phoSimStarCatalog.photParams = phot_params
+    phoSimStarCatalog = ImSimStars(starDataBase, obs_md)
+    phoSimStarCatalog.photParams = desc.imsim.photometricParameters(commands)
     phoSimStarCatalog.camera = camera
     phoSimStarCatalog.get_fitsFiles()
 
     # Now galaxies
     ImSimGalaxies = desc.imsim.imSim_class_factory(GalSimGalaxies)
-    phoSimGalaxyCatalog = ImSimGalaxies(galaxyDataBase, obs)
+    phoSimGalaxyCatalog = ImSimGalaxies(galaxyDataBase, obs_md)
     phoSimGalaxyCatalog.copyGalSimInterpreter(phoSimStarCatalog)
     phoSimGalaxyCatalog.get_fitsFiles()
 
@@ -142,7 +111,7 @@ def main():
         os.makedirs(outdir)
     prefix = config['eimage_prefix']
     phoSimGalaxyCatalog.write_images(nameRoot=os.path.join(outdir, prefix) +
-                                     str(visitID))
+                                     str(commands['obshistid']))
 
 if __name__ == "__main__":
     main()

--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -10,7 +10,6 @@ import os
 import argparse
 from lsst.obs.lsstSim import LsstSimMapper
 from lsst.sims.coordUtils import chipNameFromRaDec
-from lsst.sims.GalSimInterface import GalSimStars, GalSimGalaxies
 import desc.imsim
 
 def main():
@@ -85,23 +84,14 @@ def main():
 
     # Simulate the objects in the Pandas Dataframes.
 
-    # The GalSim[Stars,Galaxies] classes are subclassed via
-    # desc.imsim.imSim_class_factory, with the new subclass
-    # constructor taking a pandas DataFrame as a parameter instead of
-    # a CatalogDBObject.  In that constructor, the PSF and CCD noise
-    # model are set.  For simulation the LSST this should be the same
-    # between all types of objects.
-
     # First simulate stars
-    ImSimStars = desc.imsim.imSim_class_factory(GalSimStars)
-    phoSimStarCatalog = ImSimStars(starDataBase, obs_md)
+    phoSimStarCatalog = desc.imsim.ImSimStars(starDataBase, obs_md)
     phoSimStarCatalog.photParams = desc.imsim.photometricParameters(commands)
     phoSimStarCatalog.camera = camera
     phoSimStarCatalog.get_fitsFiles()
 
     # Now galaxies
-    ImSimGalaxies = desc.imsim.imSim_class_factory(GalSimGalaxies)
-    phoSimGalaxyCatalog = ImSimGalaxies(galaxyDataBase, obs_md)
+    phoSimGalaxyCatalog = desc.imsim.ImSimGalaxies(galaxyDataBase, obs_md)
     phoSimGalaxyCatalog.copyGalSimInterpreter(phoSimStarCatalog)
     phoSimGalaxyCatalog.get_fitsFiles()
 

--- a/bin.src/imsim.py
+++ b/bin.src/imsim.py
@@ -94,8 +94,8 @@ def main():
     # Now further sub-divide the source dataframe into stars and galaxies.
     if arguments.sensor is not None:
         # Trim the input catalog to a single chip.
-        raICRS = phosim_objects['ra'].values
-        decICRS = phosim_objects['dec'].values
+        raICRS = phosim_objects['raICRS'].values
+        decICRS = phosim_objects['decICRS'].values
         phosim_objects['chipName'] = chipNameFromRaDec(raICRS, decICRS,
                                                        camera=camera,
                                                        obs_metadata=obs,

--- a/python/desc/imsim/__init__.py
+++ b/python/desc/imsim/__init__.py
@@ -4,3 +4,4 @@ try:
 except ImportError:
     pass
 from .imSim import *
+from .imSim_class_factory import *

--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -168,8 +168,7 @@ def extract_objects(df):
                'majorAxis',
                'positionAngle', 'sindex',
                'internalAv', 'internalRv',
-               'galacticAv', 'galacticRv',
-               'x_pupil', 'y_pupil')
+               'galacticAv', 'galacticRv')
 
     # Process stars and galaxies separately.
     source_type = 'point'

--- a/python/desc/imsim/imSim_class_factory.py
+++ b/python/desc/imsim/imSim_class_factory.py
@@ -3,11 +3,11 @@ Code to generate imSim subclasses of GalSimBase subclasses.
 """
 from __future__ import absolute_import, print_function, division
 import gc
-#from lsst.sims.catalogs.db import CatalogDBObject
-from lsst.sims.GalSimInterface import ExampleCCDNoise, SNRdocumentPSF
+from lsst.sims.GalSimInterface import GalSimStars, GalSimGalaxies, \
+    ExampleCCDNoise, SNRdocumentPSF
 from lsst.sims.utils import pupilCoordsFromRaDec
 
-__all__ = ['imSim_class_factory']
+__all__ = ['ImSimStars', 'ImSimGalaxies']
 
 def imSim_class_factory(galsim_subclass):
     """
@@ -23,7 +23,7 @@ def imSim_class_factory(galsim_subclass):
     imSim_class.__imSim_class__ = imSim_class
     return imSim_class
 
-def imSim__init__(self, phosim_objects, obs_metadata):
+def imSim__init__(self, phosim_objects, obs_metadata, catalog_db=None):
     """
     ImSim* subclass constructor.
 
@@ -33,10 +33,14 @@ def imSim__init__(self, phosim_objects, obs_metadata):
         A DataFrame containing the instance catalog object data.
     obs_metadata : lsst.sims.utils.ObservationMetaData
         Object containing the telescope observation parameters.
+    catalog_db : lsst.sims.catalogs.db.CatalogDBObject, optional
+        CatalogDBObject to pass to InstanceCatalog superclass.
     """
-#    super(self.__imSim_class__, self).__init__(CatalogDBObject(),
-#                                               obs_metadata=obs_metadata)
-    self.obs_metadata = obs_metadata
+    if catalog_db is not None:
+        super(self.__imSim_class__, self).__init__(catalog_db,
+                                                   obs_metadata=obs_metadata)
+    else:
+        self.obs_metadata = obs_metadata
 
     xPupil, yPupil = pupilCoordsFromRaDec(phosim_objects['raICRS'].values,
                                           phosim_objects['decICRS'].values,
@@ -79,3 +83,6 @@ def imSim_column_by_name(self, colname):
     if colname not in self.phosim_objects:
         return super(self.__imSim_class__, self).column_by_name(colname)
     return self.phosim_objects[colname].values
+
+ImSimStars = imSim_class_factory(GalSimStars)
+ImSimGalaxies = imSim_class_factory(GalSimGalaxies)

--- a/python/desc/imsim/imSim_class_factory.py
+++ b/python/desc/imsim/imSim_class_factory.py
@@ -1,0 +1,80 @@
+"""
+Code to generate imSim subclasses of GalSimBase subclasses.
+"""
+from __future__ import absolute_import, print_function, division
+from lsst.sims.catalogs.db import CatalogDBObject
+from lsst.sims.GalSimInterface import ExampleCCDNoise, SNRdocumentPSF
+from lsst.sims.utils import pupilCoordsFromRaDec
+
+__all__ = ['imSim_class_factory']
+
+def imSim_class_factory(galsim_subclass):
+    """
+    Return a subclass of galsim_subclass that takes a pandas DataFrame
+    instead of a CatalogDBObject.
+    """
+    imSim_class_name = galsim_subclass.__name__.replace('GalSim', 'ImSim')
+    imSim_class = type(imSim_class_name,
+                       (galsim_subclass,),
+                       dict([('column_by_name', imSim_column_by_name),
+                             ('__init__', imSim__init__),
+                             ('__name__', imSim_class_name)]))
+    imSim_class.__imSim_class__ = imSim_class
+    return imSim_class
+
+def imSim__init__(self, phosim_objects, obs_metadata=None):
+    """
+    ImSim* subclass constructor.
+
+    Parameters
+    ----------
+
+    phosim_objects : pandas.DataFrame
+        A DataFrame containing the instance catalog object data.
+    obs_metadata : lsst.sims.utils.ObservationMetaData
+        Object containing the telescope observation parameters.
+    """
+#    super(self.__imSim_class__, self).__init__(CatalogDBObject(),
+#                                               obs_metadata=obs_metadata)
+    self.phosim_objects = phosim_objects
+    self.obs_metadata = obs_metadata
+
+    self.db_obj = type('DummyDB', (), dict(epoch=2000))
+
+    # Add noise and sky background
+    self.noise_and_background = ExampleCCDNoise(addNoise=True,
+                                                addBackground=True)
+
+    # Add a PSF.  This one Taken from equation 30 of
+    # www.astro.washington.edu/users/ivezic/Astr511/LSST_SNRdoc.pdf
+    #
+    # Set seeing from self.obs_metadata.
+    self.PSF = \
+        SNRdocumentPSF(self.obs_metadata.seeing[self.obs_metadata.bandpass])
+
+    # Add bandpasses to simulate over.
+    self.bandpassNames = list(self.obs_metadata.bandpass)
+
+    xPupil, yPupil = pupilCoordsFromRaDec(self.phosim_objects['raICRS'].values,
+                                          self.phosim_objects['decICRS'].values,
+                                          obs_metadata=obs_metadata,
+                                          epoch=2000.0)
+    self.phosim_objects.assign(x_pupil=xPupil)
+    self.phosim_objects.assign(y_pupil=yPupil)
+
+def imSim_column_by_name(self, colname):
+    """
+    Function to overload InstanceCatalog.column_by_name.
+
+    Parameters
+    ----------
+    colname : str
+        The name of the column to return.
+
+    Returns
+    -------
+    np.array
+    """
+    if colname not in self.phosim_objects:
+        return super(self.__imSim_class__, self).column_by_name(colname)
+    return self.phosim_objects[colname].values

--- a/python/desc/imsim/imSim_class_factory.py
+++ b/python/desc/imsim/imSim_class_factory.py
@@ -2,7 +2,9 @@
 Code to generate imSim subclasses of GalSimBase subclasses.
 """
 from __future__ import absolute_import, print_function, division
-from lsst.sims.catalogs.db import CatalogDBObject
+import warnings
+import pandas as pd
+#from lsst.sims.catalogs.db import CatalogDBObject
 from lsst.sims.GalSimInterface import ExampleCCDNoise, SNRdocumentPSF
 from lsst.sims.utils import pupilCoordsFromRaDec
 
@@ -59,8 +61,12 @@ def imSim__init__(self, phosim_objects, obs_metadata=None):
                                           self.phosim_objects['decICRS'].values,
                                           obs_metadata=obs_metadata,
                                           epoch=2000.0)
-    self.phosim_objects.assign(x_pupil=xPupil)
-    self.phosim_objects.assign(y_pupil=yPupil)
+
+    index = self.phosim_objects.index
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore')
+        self.phosim_objects.loc[:, 'x_pupil'] = pd.Series(xPupil, index=index)
+        self.phosim_objects.loc[:, 'y_pupil'] = pd.Series(yPupil, index=index)
 
 def imSim_column_by_name(self, colname):
     """

--- a/tests/test_imSim_class_factory.py
+++ b/tests/test_imSim_class_factory.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for imSim_class_factory module.
+"""
+from __future__ import absolute_import
+import os
+import unittest
+from lsst.sims.GalSimInterface import GalSimStars
+import desc.imsim
+
+class ImSimClassFactoryTestCase(unittest.TestCase):
+    "TestCase class for imSim_class_factory."
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_imSim_class_factory(self):
+        "Test code for imSim_class_factory."
+        instcat_file = os.path.join(os.environ['IMSIM_DIR'], 'tests',
+                                    'tiny_instcat.txt')
+        commands, objects = desc.imsim.parsePhoSimInstanceFile(instcat_file)
+        ImSimStars = desc.imsim.imSim_class_factory(GalSimStars)
+        obs_md = desc.imsim.phosim_obs_metadata(commands)
+        stars = ImSimStars(objects.query("galSimType=='pointSource'"), obs_md)
+        self.assertEqual(stars.column_by_name('uniqueId')[0], 1046817878020)
+        self.assertAlmostEqual(stars.column_by_name('x_pupil')[0], -0.0008283)
+        self.assertAlmostEqual(stars.column_by_name('y_pupil')[0], -0.00201296)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_imSim_class_factory.py
+++ b/tests/test_imSim_class_factory.py
@@ -4,7 +4,6 @@ Unit tests for imSim_class_factory module.
 from __future__ import absolute_import
 import os
 import unittest
-from lsst.sims.GalSimInterface import GalSimStars
 import desc.imsim
 
 class ImSimClassFactoryTestCase(unittest.TestCase):
@@ -20,9 +19,10 @@ class ImSimClassFactoryTestCase(unittest.TestCase):
         instcat_file = os.path.join(os.environ['IMSIM_DIR'], 'tests',
                                     'tiny_instcat.txt')
         commands, objects = desc.imsim.parsePhoSimInstanceFile(instcat_file)
-        ImSimStars = desc.imsim.imSim_class_factory(GalSimStars)
         obs_md = desc.imsim.phosim_obs_metadata(commands)
-        stars = ImSimStars(objects.query("galSimType=='pointSource'"), obs_md)
+        stars = \
+            desc.imsim.ImSimStars(objects.query("galSimType=='pointSource'"),
+                                  obs_md)
         self.assertEqual(stars.column_by_name('uniqueId')[0], 1046817878020)
         self.assertAlmostEqual(stars.column_by_name('x_pupil')[0], -0.0008283)
         self.assertAlmostEqual(stars.column_by_name('y_pupil')[0], -0.00201296)

--- a/tests/test_instcat_parser.py
+++ b/tests/test_instcat_parser.py
@@ -42,15 +42,15 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
 
         star = \
             instcat_contents.objects.query("galSimType=='pointSource'").iloc[0]
-        self.assertEqual(star['objectID'], 1046817878020)
-        self.assertAlmostEqual(star['ra'], 31.2400746)
-        self.assertAlmostEqual(star['dec'], -10.09365)
-        self.assertEqual(star['sedName'], 'starSED/phoSimMLT/lte033-4.5-1.0a+0.4.BT-Settl.spec.gz')
+        self.assertEqual(star['uniqueId'], 1046817878020)
+        self.assertAlmostEqual(star['raICRS'], 31.2400746)
+        self.assertAlmostEqual(star['decICRS'], -10.09365)
+        self.assertEqual(star['sedFilepath'], 'starSED/phoSimMLT/lte033-4.5-1.0a+0.4.BT-Settl.spec.gz')
 
         galaxy = instcat_contents.objects.query("galSimType=='sersic'").iloc[0]
-        self.assertEqual(galaxy['objectID'], 34308924793883)
+        self.assertEqual(galaxy['uniqueId'], 34308924793883)
         self.assertAlmostEqual(galaxy['positionAngle'], 2.77863669)
-        self.assertEqual(galaxy['sersicIndex'], 1)
+        self.assertEqual(galaxy['sindex'], 1)
 
         self.assertRaises(desc.imsim.PhosimInstanceCatalogParseError,
                           desc.imsim.parsePhoSimInstanceFile,
@@ -79,8 +79,8 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
                 desc.imsim.validate_phosim_object_list(instcat_contents.objects)
         self.assertEqual(len(rejected), 2)
         self.assertEqual(len(accepted), 19)
-        self.assertEqual(len(rejected.query("halfLightSemiMinor > halfLightSemiMajor")), 1)
-        self.assertEqual(len(rejected.query("magNorm>50")), 1)
+        self.assertEqual(len(rejected.query("minorAxis > majorAxis")), 1)
+        self.assertEqual(len(rejected.query("magNorm > 50")), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Here's a proposal to use subclassing instead of using the `monkeyPatchedGalSimBase.py` code.  It's all on the client-side, i.e., it doesn't require any sims code to be modified, which is probably a good thing.

I've only exercised it on `tests/tiny_instcat.txt`, so I need to do more testing as well as add real unit test code.  Opening this PR so people can comment on the approach.