### PR TITLE
allow comments and optional commands

### DIFF
--- a/python/desc/imsim/imSim.py
+++ b/python/desc/imsim/imSim.py
@@ -29,7 +29,7 @@ class PhosimInstanceCatalogParseError(RuntimeError):
 PhoSimInstanceCatalogContents = namedtuple('PhoSimInstanceCatalogContents',
                                            ('commands', 'objects'))
 
-_expected_commands = set("""rightascension
+_required_commands = set("""rightascension
 declination
 mjd
 altitude
@@ -88,7 +88,7 @@ def parsePhoSimInstanceFile(fileName, numRows=None):
                    'PAR5', 'PAR6', 'PAR7', 'PAR8', 'PAR9', 'PAR10']
 
     dataFrame = pd.read_csv(fileName, names=columnNames, nrows=numRows,
-                            delim_whitespace=True)
+                            delim_whitespace=True, comment='#')
 
     # Any missing items from the end of the lines etc were turned into NaNs by
     # Pandas to represent that they were missing.  This causes problems later
@@ -100,11 +100,18 @@ def parsePhoSimInstanceFile(fileName, numRows=None):
     phoSimHeaderCards = dataFrame.query("STRING != 'object'")
     phoSimSources = dataFrame.query("STRING == 'object'")
 
-    # Check that the commands match the expected set.
+    # Check that the required commands are present in the instance catalog.
     command_set = set(phoSimHeaderCards['STRING'])
-    if command_set != _expected_commands:
-        message = "Commands from the instance catalog %s do match the expected set: " % fileName + str(command_set - _expected_commands) + str(_expected_commands - command_set)
+    missing_commands = _required_commands - command_set
+    if missing_commands:
+        message = "\nRequired commands that are missing from the instance catalog %s:\n   " % fileName + "\n   ".join(missing_commands)
         raise PhosimInstanceCatalogParseError(message)
+
+    # Report on commands that are not part of the required set.
+    extra_commands = command_set - _required_commands
+    if extra_commands:
+        message = "\nExtra commands in the instance catalog %s that are not in the required set:\n   " % fileName + "\n   ".join(extra_commands)
+        warnings.warn(message)
 
     # Turn the list of commands into a dictionary.
     commands = extract_commands(phoSimHeaderCards)

--- a/tests/test_instcat_parser.py
+++ b/tests/test_instcat_parser.py
@@ -22,14 +22,18 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
     def setUp(self):
         self.command_file = os.path.join(os.environ['IMSIM_DIR'],
                                          'tests', 'tiny_instcat.txt')
+        self.extra_commands = 'instcat_extra.txt'
+        with open(self.extra_commands, 'w') as output:
+            for line in open(self.command_file).readlines()[:20]:
+                output.write(line)
+            output.write('extra_command 1\n')
 
     def tearDown(self):
-        pass
+        os.remove(self.extra_commands)
 
     def test_parsePhoSimInstanceFile(self):
         "Test code for parsePhoSimInstanceFile."
-        instcat_contents = \
-            desc.imsim.parsePhoSimInstanceFile(self.command_file)
+        instcat_contents = desc.imsim.parsePhoSimInstanceFile(self.command_file)
         # Test a handful of values directly:
         self.assertEqual(instcat_contents.commands['obshistid'], 161899)
         self.assertEqual(instcat_contents.commands['filter'], 2)
@@ -56,6 +60,14 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
                           desc.imsim.parsePhoSimInstanceFile,
                           self.command_file, 10)
 
+    def test_parsePhoSimInstanceFile_warning(self):
+        "Test the warnings emitted by the instance catalog parser."
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.assertRaises(UserWarning,
+                              desc.imsim.parsePhoSimInstanceFile,
+                              self.extra_commands)
+
     def test_photometricParameters(self):
         "Test the photometricParameters function."
         instcat_contents = \
@@ -71,8 +83,7 @@ class InstanceCatalogParserTestCase(unittest.TestCase):
 
     def test_validate_phosim_object_list(self):
         "Test the validation of the rows of the phoSimObjects DataFrame."
-        instcat_contents = \
-            desc.imsim.parsePhoSimInstanceFile(self.command_file)
+        instcat_contents = desc.imsim.parsePhoSimInstanceFile(self.command_file)
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', 'Omitted', UserWarning)
             accepted, rejected = \

--- a/tests/tiny_instcat.txt
+++ b/tests/tiny_instcat.txt
@@ -1,3 +1,4 @@
+#comment
 rightascension 31.1133844
 declination -10.0970060
 mjd 59797.2854090


### PR DESCRIPTION
This is basically done.   One additional change to consider would be to put the list of expected phosim commands in `data/default_imsim_configs` or perhaps some other configuration file that could be overridden at runtime instead of [hard-wiring them](https://github.com/DarkEnergyScienceCollaboration/imSim/blob/master/python/desc/imsim/imSim.py#L33).  